### PR TITLE
Auto-focus number input on backspace.

### DIFF
--- a/phone/scripts/app.js
+++ b/phone/scripts/app.js
@@ -605,6 +605,13 @@ $(document).ready(function() {
         ctxSip.newSession(s);
     });
 
+    // Auto-focus number input on backspace.
+    $('#sipClient').keydown(function(event) {
+        if (event.which === 8) {
+            $('#numDisplay').focus();
+        }
+    });
+
     $('#numDisplay').keypress(function(e) {
         // Enter pressed? so Dial.
         if (e.which === 13) {


### PR DESCRIPTION
It's nice if a user doesn't have to explicitly click on the number field to delete digits from it.

It's only a little thing, but pretty easy to contribute.
