### PR TITLE
Broken reconnect functionality

### DIFF
--- a/phone/scripts/app.js
+++ b/phone/scripts/app.js
@@ -547,18 +547,14 @@ $(document).ready(function() {
 
     ctxSip.phone.on('connected', function(e) {
         ctxSip.setStatus("Connected");
+        
+        ctxSip.setError(false)
     });
 
     ctxSip.phone.on('disconnected', function(e) {
         ctxSip.setStatus("Disconnected");
-
-        // disable phone
+        
         ctxSip.setError(true, 'Websocket Disconnected.', 'An Error occurred connecting to the websocket.');
-
-        // remove existing sessions
-        $("#sessions > .session").each(function(i, session) {
-            ctxSip.removeSession(session, 500);
-        });
     });
 
     ctxSip.phone.on('registered', function(e) {


### PR DESCRIPTION
When you disconnect from SIP server, then SIP.js tries to reconnect. But ctxSip removes all sessions after disconnection so user will be never connected again.